### PR TITLE
Smaller image with multistage build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,65 +1,73 @@
-#installs all dependencies and builds srsLTE 2.0 >
+ARG UBUNTU_VERSION=xenial
 
-#the executable for ue can be found in /srs
-#the source code and build directories can be found in /git
-#run with docker run -i -t --privileged -v /dev/bus/usb:/dev/bus/usb <image> bash
-#use uhd_find_device to check if the container sees the USRP
+# Intermediate builder container
+FROM ubuntu:${UBUNTU_VERSION} as builder
+ARG UBUNTU_VERSION
+ARG SRSLTE_REPO=https://github.com/srsLTE/srsLTE
+ARG SRSLTE_CHECKOUT=master
 
-FROM ubuntu:16.04
-MAINTAINER razorheadfx <razorhead.effect@gmail.com>
-
-RUN echo "Installing deps" \
+# Install build dependencies
+RUN echo "deb http://ppa.launchpad.net/ettusresearch/uhd/ubuntu \
+          ${UBUNTU_VERSION} main" > /etc/apt/sources.list.d/uhd-latest.list \
+ && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 6169358E \
  && apt-get update \
- && apt-get install -y software-properties-common \
- && add-apt-repository -y ppa:ettusresearch/uhd \
- && apt-get update \
- && echo "Basics" \
  && apt-get install -y \
-        gcc \
-        git \
-        make \
-        cmake \
         build-essential \
-        pkg-config \
-        nano \
-        moreutils \
- && echo "Installing and downloading uhd software and fpga image" \
+        git \
+        cmake \
+        libuhd-dev \
+        uhd-host \
+        libuhd003 \
+        libboost-all-dev \
+        # warning: pulled libboost-all-dev because libboost(-dev) alone left
+        # cmake unable to find boost when building the makefiles for srsUE
+        libvolk1-dev \
+        libfftw3-dev \
+        libmbedtls-dev \
+        libsctp-dev \
+        libconfig++-dev \
+ && rm -rf /var/lib/apt/lists/*
+
+# Clone repo and build
+RUN mkdir /srslte \
+ && cd /srslte \
+ && git clone $SRSLTE_REPO srslte \
+ && cd srslte \
+ && git checkout $SRSLTE_CHECKOUT \
+ && cd .. \
+ && mkdir build \
+ && cd build \
+ && cmake -DCMAKE_INSTALL_PREFIX:PATH=/opt/srslte ../srslte \
+ && make install
+
+
+# Final container
+FROM ubuntu:${UBUNTU_VERSION}
+ARG UBUNTU_VERSION
+
+# Install runtime dependencies
+RUN echo "deb http://ppa.launchpad.net/ettusresearch/uhd/ubuntu \
+          ${UBUNTU_VERSION} main" > /etc/apt/sources.list.d/uhd-latest.list \
+ && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 6169358E \
+ && apt-get update \
  && apt-get install -y \
         libuhd-dev \
         uhd-host \
         libuhd003 \
  && python /usr/lib/uhd/utils/uhd_images_downloader.py \
- && echo "Installing deps" \
  && apt-get install -y \
-     libboost-all-dev \
-     # warning: pulled libboost-all-dev because libboost(-dev) alone left cmake
-     # unable to find boost when building the makefiles for srsUE
-     libvolk1-bin \
-     libvolk1-dev \
-     libfftw3-bin \
-     libfftw3-dev \
-     libmbedtls-dev \
+     libvolk1.1 \
+     libfftw3-3 \
      libmbedtls10 \
-     libsctp-dev \
-     lksctp-tools \
-     libconfig-dev \
-     libconfig++-dev \
+     libsctp1 \
+     libconfig++9v5 \
  && rm -rf /var/lib/apt/lists/*
 
-#make build dirs
-RUN echo "Building srsLTE" \
- && mkdir git \
- && cd git \
- && git clone https://github.com/srsLTE/srsLTE.git \
- && mkdir srsLTE/build \
- && echo "Building srsLTE" \
- && cd srsLTE/build \
- && cmake .. \
- && make install
+# Get compiled srsLTE
+COPY --from=builder /opt/srslte /opt/srslte
+
+# Set up paths
+ENV LD_LIBRARY_PATH /opt/srslte/lib:$LD_LIBRARY_PATH
+ENV PATH /opt/srslte/bin:$PATH
 
 WORKDIR /conf
-
-# RUN echo "Setting up PATH"
-ENV PATH "/git/srsLTE/build/lib/examples:$PATH"
-ENV PATH "/git/srsLTE/build/srsenb/src:$PATH"
-ENV PATH "/git/srsLTE/build/srsue/src:$PATH"

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,6 @@ RUN echo "deb http://ppa.launchpad.net/ettusresearch/uhd/ubuntu \
         cmake \
         libuhd-dev \
         uhd-host \
-        libuhd003 \
         libboost-all-dev \
         # warning: pulled libboost-all-dev because libboost(-dev) alone left
         # cmake unable to find boost when building the makefiles for srsUE
@@ -51,16 +50,14 @@ RUN echo "deb http://ppa.launchpad.net/ettusresearch/uhd/ubuntu \
  && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 6169358E \
  && apt-get update \
  && apt-get install -y \
-        libuhd-dev \
         uhd-host \
         libuhd003 \
+       libvolk1.1 \
+       libfftw3-3 \
+       libmbedtls10 \
+       libsctp1 \
+       libconfig++9v5 \
  && python /usr/lib/uhd/utils/uhd_images_downloader.py \
- && apt-get install -y \
-     libvolk1.1 \
-     libfftw3-3 \
-     libmbedtls10 \
-     libsctp1 \
-     libconfig++9v5 \
  && rm -rf /var/lib/apt/lists/*
 
 # Get compiled srsLTE

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,36 +8,58 @@
 FROM ubuntu:16.04
 MAINTAINER razorheadfx <razorhead.effect@gmail.com>
 
-RUN echo "Installing basics"
-RUN apt-get update
-RUN apt-get install -y software-properties-common gcc git make cmake build-essential pkg-config nano moreutils
-
-RUN echo "Installing and downloading uhd software and fpga image"
-RUN add-apt-repository -y ppa:ettusresearch/uhd 
-RUN apt-get update 
-RUN apt-get install -y libuhd-dev uhd-host libuhd003
-RUN python /usr/lib/uhd/utils/uhd_images_downloader.py
+RUN echo "Installing deps" \
+ && apt-get update \
+ && apt-get install -y software-properties-common \
+ && add-apt-repository -y ppa:ettusresearch/uhd \
+ && apt-get update \
+ && echo "Basics" \
+ && apt-get install -y \
+        gcc \
+        git \
+        make \
+        cmake \
+        build-essential \
+        pkg-config \
+        nano \
+        moreutils \
+ && echo "Installing and downloading uhd software and fpga image" \
+ && apt-get install -y \
+        libuhd-dev \
+        uhd-host \
+        libuhd003 \
+ && python /usr/lib/uhd/utils/uhd_images_downloader.py \
+ && echo "Installing deps" \
+ && apt-get install -y \
+     libboost-all-dev \
+     # warning: pulled libboost-all-dev because libboost(-dev) alone left cmake
+     # unable to find boost when building the makefiles for srsUE
+     libvolk1-bin \
+     libvolk1-dev \
+     libfftw3-bin \
+     libfftw3-dev \
+     libmbedtls-dev \
+     libmbedtls10 \
+     libsctp-dev \
+     lksctp-tools \
+     libconfig-dev \
+     libconfig++-dev \
+ && rm -rf /var/lib/apt/lists/*
 
 #make build dirs
-RUN echo "Setting up build dir"
-RUN mkdir git
-WORKDIR git
-RUN git clone https://github.com/srsLTE/srsLTE.git
-RUN mkdir srsLTE/build
-
-RUN echo "Installing deps"
-RUN apt-get install -y libboost-all-dev
-#warning: pulled libboost-all-dev because libboost(-dev) alone left cmake unable to find boost when building the makefiles for srsUE
-RUN apt-get install -y libvolk1-bin libvolk1-dev libfftw3-bin libfftw3-dev libmbedtls-dev libmbedtls10 libsctp-dev lksctp-tools libconfig-dev libconfig++-dev
-
-RUN echo "Building srsLTE"
-WORKDIR /git/srsLTE/build
-RUN cmake ..
-RUN make install
+RUN echo "Building srsLTE" \
+ && mkdir git \
+ && cd git \
+ && git clone https://github.com/srsLTE/srsLTE.git \
+ && mkdir srsLTE/build \
+ && echo "Building srsLTE" \
+ && cd srsLTE/build \
+ && cmake .. \
+ && make install
 
 WORKDIR /conf
 
-RUN echo "Setting up PATH"
-ENV PATH="/git/srsLTE/build/lib/examples:${PATH}"
-ENV PATH="/git/srsLTE/build/srsenb/src:${PATH}"
-ENV PATH="/git/srsLTE/build/srsue/src:${PATH}"
+# RUN echo "Setting up PATH"
+ENV PATH "/git/srsLTE/build/lib/examples:$PATH"
+ENV PATH "/git/srsLTE/build/srsenb/src:$PATH"
+ENV PATH "/git/srsLTE/build/srsue/src:$PATH"

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Pulls the srsLTE project [srsLTE] (> 2.0), the USRP drivers from the [Ettus
 Research PPA] and builds both eNodeB and UE binaries with the USRP as targeted
 SDR front-end.
 
+Since this is a [multistage] build, you need at least **Docker 17.05**.
+
 Build with:
 
     docker build -t srs docker-srslte-usrp

--- a/README.md
+++ b/README.md
@@ -10,13 +10,6 @@ Build with:
 
     docker build -t srs docker-srslte-usrp
 
-**Note** until https://github.com/srsLTE/srsLTE/pull/88 is merged, use:
-
-    docker build -t srs --build-arg SRSLTE_REPO=https://github.com/pgorczak/srsLTE docker-srslte-usrp
-
-If it gets rejected, we should adapt *Dockerfile* accordingly (copy executables
-from build dir).
-
 ## Build args
 
 * `UBUNTU_VERSION` codename of the base Ubuntu (default `xenial`)

--- a/README.md
+++ b/README.md
@@ -1,25 +1,47 @@
 ## A USRP-friendly image for LTE experimentation
 
-Pulls the srsLTE project [srsLTE](https://github.com/srslte/srslte) (> 2.0),  the USRP drivers from the [Ettus Research PPA](https://launchpad.net/~ettusresearch/+archive/ubuntu/uhd) and builds both eNodeB and UE binaries with the USRP as targeted SDR front-end.
+Pulls the srsLTE project [srsLTE] (> 2.0), the USRP drivers from the [Ettus
+Research PPA] and builds both eNodeB and UE binaries with the USRP as targeted
+SDR front-end.
 
 Build with:
 
-    docker build -t srs docker-srslte-usrp/
+    docker build -t srs docker-srslte-usrp
+
+**Note** until https://github.com/srsLTE/srsLTE/pull/88 is merged, use:
+
+    docker build -t srs --build-arg SRSLTE_REPO=https://github.com/pgorczak/srsLTE docker-srslte-usrp
+
+If it gets rejected, we should adapt *Dockerfile* accordingly (copy executables
+from build dir).
+
+## Build args
+
+* `UBUNTU_VERSION` codename of the base Ubuntu (default `xenial`)
+* `SRSLTE_REPO` source repo of srsLTE (default
+  `https://github.com/srsLTE/srsLTE`)
+* `SRSLTE_CHECKOUT` branch/tag/commit to check out (default `master`)
+
+## Deploy
 
 Run with:
-```
-#this also mounts the conf directory to /conf for convenient ue config editing on the host
-#cd docker-srslte-usrp
-start.sh
-```
 
-Run eNodeB directly:
+    start.sh
 
-    bash -c "srsenb enb.conf & tail --follow=/tmp/enb.log --retry"
+This also mounts the conf directory to /conf for convenient config editing on
+the host. Get example configs from the *srsenb* and *srsue* folders of the
+source repo.
 
-TODO:
-- [ ] [reduce size][multistage] (built image weighs in around 1.15GB)
+Run eNodeB directly (on the container):
+
+    bash -c "srsenb enb.conf & tail --follow --retry /tmp/enb.log"
+
+Use `uhd_find_device` to check if the container sees the USRP.
+
+## TODO
 - [ ] figure out required capabilities (instead of `--privileged`)
 
 
+[srsLTE]: https://github.com/srslte/srslte
+[Ettus Research PPA]: https://launchpad.net/~ettusresearch/+archive/ubuntu/uhd
 [multistage]: https://docs.docker.com/engine/userguide/eng-image/multistage-build/

--- a/README.md
+++ b/README.md
@@ -1,18 +1,25 @@
 ## A USRP-friendly image for LTE experimentation
-  
+
 Pulls the srsLTE project [srsLTE](https://github.com/srslte/srslte) (> 2.0),  the USRP drivers from the [Ettus Research PPA](https://launchpad.net/~ettusresearch/+archive/ubuntu/uhd) and builds both eNodeB and UE binaries with the USRP as targeted SDR front-end.
 
 Build with:
-```
-docker build -t srs docker-srslte-usrp/
-```
-  
+
+    docker build -t srs docker-srslte-usrp/
+
 Run with:
 ```
 #this also mounts the conf directory to /conf for convenient ue config editing on the host
 #cd docker-srslte-usrp
 start.sh
 ```
-  
-TODO:  
- - [ ] reduce size (built image weighs in around 1.15GB)
+
+Run eNodeB directly:
+
+    bash -c "srsenb enb.conf & tail --follow=/tmp/enb.log --retry"
+
+TODO:
+- [ ] [reduce size][multistage] (built image weighs in around 1.15GB)
+- [ ] figure out required capabilities (instead of `--privileged`)
+
+
+[multistage]: https://docs.docker.com/engine/userguide/eng-image/multistage-build/


### PR DESCRIPTION
Starting with 17.05, we can use [multistage](https://docs.docker.com/engine/userguide/eng-image/multistage-build/) builds to get nicer image sizes. It now clocks in at 457MB. I also added some build args. Since we need to define an install dir, there is the new issue of getting the eNB/UE binaries. Currently proposing https://github.com/srsLTE/srsLTE/pull/88 to make that easier.